### PR TITLE
fix: get-path-prefix not found error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v4
+        with:
+          repository: AdobeDocs/adp-devsite-scripts
+          path: scripts
+          ref: main
+
       - name: Get pathPrefix
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: get_path_prefix
         with:
           script: |
-            const script = require('./.github/scripts/get-path-prefix.js');
+            const script = require('./scripts/gatsby-get-path-prefix.js');
             script({ core });
           result-encoding: string
 


### PR DESCRIPTION
Fix deploy error:
<img width="1591" height="1039" alt="Screenshot 2025-11-04 at 8 31 00 AM" src="https://github.com/user-attachments/assets/7623728b-e88a-4a29-974a-42b3b9a20904" />